### PR TITLE
Adding NavigationEntry wrapper method for getting history page title.

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1103,6 +1103,14 @@ const GURL& WebContents::GetURLAtIndex(int index) const {
     return GURL::EmptyGURL();
 }
 
+const base::string16 WebContents::GetTitleAtIndex(int index) const {
+  auto entry = web_contents()->GetController().GetEntryAtIndex(index);
+  if (entry)
+    return entry->GetTitle();
+  else
+    return base::string16();
+}
+
 // TODO(bridiver) there should be a more generic way
 // to set renderer preferences in general
 const std::string& WebContents::GetWebRTCIPHandlingPolicy() const {
@@ -1690,6 +1698,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("canGoForward", &WebContents::CanGoForward)
       .SetMethod("canGoToOffset", &WebContents::CanGoToOffset)
       .SetMethod("getURLAtIndex", &WebContents::GetURLAtIndex)
+      .SetMethod("getTitleAtIndex", &WebContents::GetTitleAtIndex)
       .SetMethod("getEntryCount", &WebContents::GetEntryCount)
       .SetMethod("getCurrentEntryIndex", &WebContents::GetCurrentEntryIndex)
       .SetMethod("getLastCommittedEntryIndex",

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -112,6 +112,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   bool CanGoForward() const;
   void GoToIndex(int index);
   const GURL& GetURLAtIndex(int index) const;
+  const base::string16 GetTitleAtIndex(int index) const;
   int GetCurrentEntryIndex() const;
   int GetLastCommittedEntryIndex() const;
   int GetEntryCount() const;

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "start": "python ./script/start.py",
     "cibuild-windows": "rm -Rf node_mdules && python ./script/cibuild --target_arch=x64",
     "cibuild-windows-ia32": "rm -Rf node_mdules && python ./script/cibuild --target_arch=ia32",
-    "test": "python ./script/test.py"
+    "test": "python ./script/test.py",
+    "install": "npm run build && rsync -avz --delete out/D/Brave.app ../browser-laptop/node_modules/electron-prebuilt/dist/"
   }
 }


### PR DESCRIPTION
cc: @bridiver 

Getting familiar with electron :smile: Adding a method to help w/ getting information used in history.

Would be great if you can help me understand how to test locally (I tried a few things, no luck- I'm ready to update docs after I figure it out)