### PR TITLE
Add session method to enable Brotli compression

### DIFF
--- a/atom/browser/api/atom_api_session.cc
+++ b/atom/browser/api/atom_api_session.cc
@@ -112,6 +112,11 @@ void SetUserAgentInIO(scoped_refptr<net::URLRequestContextGetter> getter,
           user_agent));
 }
 
+void SetEnableBrotliInIO(scoped_refptr<net::URLRequestContextGetter> getter,
+                         bool enabled) {
+  getter->GetURLRequestContext()->set_enable_brotli(enabled);
+}
+
 }  // namespace
 
 namespace mate {
@@ -508,6 +513,13 @@ std::string Session::GetUserAgent() {
   return browser_context_->GetUserAgent();
 }
 
+void Session::SetEnableBrotli(bool enabled) {
+  auto getter = browser_context_->GetRequestContext();
+  getter->GetNetworkTaskRunner()->PostTask(
+      FROM_HERE,
+      base::Bind(&SetEnableBrotliInIO, getter, enabled));
+}
+
 v8::Local<v8::Value> Session::Cookies(v8::Isolate* isolate) {
   if (cookies_.IsEmpty()) {
     auto handle = atom::api::Cookies::Create(isolate, browser_context());
@@ -605,6 +617,7 @@ void Session::BuildPrototype(v8::Isolate* isolate,
                  &Session::AllowNTLMCredentialsForDomains)
       .SetMethod("setUserAgent", &Session::SetUserAgent)
       .SetMethod("getUserAgent", &Session::GetUserAgent)
+      .SetMethod("setEnableBrotli", &Session::SetEnableBrotli)
       .SetMethod("equal", &Session::Equal)
       .SetProperty("userPrefs", &Session::UserPrefs)
       .SetProperty("cookies", &Session::Cookies)

--- a/atom/browser/api/atom_api_session.h
+++ b/atom/browser/api/atom_api_session.h
@@ -76,6 +76,7 @@ class Session: public mate::TrackableObject<Session>,
   void AllowNTLMCredentialsForDomains(const std::string& domains);
   void SetUserAgent(const std::string& user_agent, mate::Arguments* args);
   std::string GetUserAgent();
+  void SetEnableBrotli(bool enabled);
   v8::Local<v8::Value> Cookies(v8::Isolate* isolate);
   v8::Local<v8::Value> Protocol(v8::Isolate* isolate);
   v8::Local<v8::Value> WebRequest(v8::Isolate* isolate);


### PR DESCRIPTION
This is needed for https://github.com/brave/browser-laptop/issues/2890.
Maybe it should just be on by default instead of as a session method, not sure.

Auditors: @bbondy