### PR TITLE
Expose NavigationController::IsInitialBlankNavigation

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -1082,6 +1082,10 @@ base::string16 WebContents::GetTitle() const {
   return web_contents()->GetTitle();
 }
 
+bool WebContents::IsInitialBlankNavigation() const {
+  return web_contents()->GetController().IsInitialBlankNavigation();
+}
+
 bool WebContents::IsLoading() const {
   return web_contents()->IsLoading();
 }
@@ -1850,6 +1854,7 @@ void WebContents::BuildPrototype(v8::Isolate* isolate,
       .SetMethod("downloadURL", &WebContents::DownloadURL)
       .SetMethod("getURL", &WebContents::GetURL)
       .SetMethod("getTitle", &WebContents::GetTitle)
+      .SetMethod("isInitialBlankNavigation", &WebContents::IsInitialBlankNavigation)
       .SetMethod("isLoading", &WebContents::IsLoading)
       .SetMethod("isLoadingMainFrame", &WebContents::IsLoadingMainFrame)
       .SetMethod("isWaitingForResponse", &WebContents::IsWaitingForResponse)

--- a/atom/browser/api/atom_api_web_contents.h
+++ b/atom/browser/api/atom_api_web_contents.h
@@ -104,6 +104,7 @@ class WebContents : public mate::TrackableObject<WebContents>,
   void DownloadURL(const GURL& url);
   GURL GetURL() const;
   base::string16 GetTitle() const;
+  bool IsInitialBlankNavigation() const;
   bool IsLoading() const;
   bool IsLoadingMainFrame() const;
   bool IsWaitingForResponse() const;

--- a/docs/api/web-contents.md
+++ b/docs/api/web-contents.md
@@ -534,6 +534,10 @@ Returns a Boolean, whether the web page is destroyed.
 
 Returns a Boolean, whether the web page is focused.
 
+#### `contents.isInitialBlankNavigation()`
+
+Returns a boolean, whether the web page has not yet committed a navigation.
+
 #### `contents.isLoading()`
 
 Returns whether web page is still loading resources.

--- a/docs/api/web-view-tag.md
+++ b/docs/api/web-view-tag.md
@@ -248,6 +248,10 @@ Returns URL of guest page.
 
 Returns the title of guest page.
 
+### `<webview>.isInitialBlankNavigation()`
+
+Returns a boolean, whether guest page has not yet committed a navigation.
+
 ### `<webview>.isLoading()`
 
 Returns a boolean whether guest page is still loading resources.

--- a/lib/renderer/web-view/web-view.js
+++ b/lib/renderer/web-view/web-view.js
@@ -392,6 +392,7 @@ var registerWebViewElement = function () {
     'getURL',
     'loadURL',
     'getTitle',
+    'isInitialBlankNavigation',
     'isLoading',
     'isLoadingMainFrame',
     'isWaitingForResponse',


### PR DESCRIPTION
To help detect frame initial state change.

Prereq for fixing https://github.com/brave/browser-laptop/issues/3162

For an example using this, see https://github.com/brave/browser-laptop/compare/master...ayumi:add-is-initial-blank-navigation?expand=1