### PR TITLE
Added npm task for copying on Windows; updated docs

### DIFF
--- a/docs/development/build-instructions-windows.md
+++ b/docs/development/build-instructions-windows.md
@@ -38,7 +38,7 @@ there is no Visual Studio project generated.
 
 ```powershell
 $ cd electron
-$ python script\bootstrap.py -v
+$ npm run bootstrap
 ```
 
 ## Building
@@ -52,7 +52,7 @@ $ python script\build.py
 You can also only build the Debug target:
 
 ```powershell
-$ python script\build.py -c D
+$ npm run build
 ```
 
 After building is done, you can find `electron.exe` under `out\D` (debug

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "cibuild-windows-ia32": "rm -Rf node_mdules && python ./script/cibuild --target_arch=ia32",
     "test": "python ./script/test.py",
     "browser-build": "npm run build && rsync -avz --delete out/D/Brave.app ../browser-laptop/node_modules/electron-prebuilt/dist/",
+    "browser-copy-windows": "xcopy .\\out\\D\\* ..\\browser-laptop\\node_modules\\electron-prebuild\\dist\\ /Y /S /I /F /R",
     "libchromium-build": "../libchromiumcontent/script/bootstrap && ../libchromiumcontent/script/update && ../libchromiumcontent/script/build && ../libchromiumcontent/script/create-dist --no_zip",
     "libchromium-bootstrap": "./script/bootstrap.py -v --libcc_source_path ../libchromiumcontent/dist/main/src --libcc_shared_library_path ../libchromiumcontent/dist/main/shared_library --libcc_static_library_path ../libchromiumcontent/dist/main/static_library"
   }


### PR DESCRIPTION
Created while troubleshooting https://github.com/brave/browser-laptop/issues/3142

- Added npm task for installing local electron into browser-laptop
- Updated two lines in docs to reference npm  tasks