### PR TITLE
Fix linking issue on Windows; add reference to crypt32.lib

### DIFF
--- a/autofill.gypi
+++ b/autofill.gypi
@@ -50,6 +50,7 @@
           '<(libchromiumcontent_dir)/signin_core_browser.lib',
           '<(libchromiumcontent_dir)/signin_core_common.lib',
           '<(libchromiumcontent_dir)/os_crypt.lib',
+          '-lcrypt32.lib',
         ],
       },
     }],


### PR DESCRIPTION
 used by CryptProtectData / CryptUnprotectData.

Auditors: @darkdh

Tested on Windows 10 and it works great :smile: 