### PR TITLE
Fixes mouse coordinates for Windows when display is set to a higher DPI

### DIFF
--- a/atom/renderer/atom_render_view_observer.cc
+++ b/atom/renderer/atom_render_view_observer.cc
@@ -132,8 +132,9 @@ void AtomRenderViewObserver::DraggableRegionsChanged(blink::WebFrame* frame) {
   blink::WebVector<blink::WebDraggableRegion> webregions =
       frame->document().draggableRegions();
   std::vector<DraggableRegion> regions;
-  for (const auto& webregion : webregions) {
+  for (auto& webregion : webregions) {
     DraggableRegion region;
+    render_view()->ConvertViewportToWindowViaWidget(&webregion.bounds);
     region.bounds = webregion.bounds;
     region.draggable = webregion.draggable;
     regions.push_back(region);


### PR DESCRIPTION
Fixes mouse coordinates for Windows when display is set to a higher DPI (ex: enlarged by 150% using display settings)

Fixes upstream electron issue https://github.com/electron/electron/issues/7347

Auditors: @bridiver @bbondy 