### PR TITLE
Possible fix for issues seen on frameless window (Windows) when at 200%

### DIFF
--- a/atom/browser/native_window_views.cc
+++ b/atom/browser/native_window_views.cc
@@ -1155,9 +1155,6 @@ void NativeWindowViews::OnWidgetMove() {
 
 gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
     const gfx::Rect& bounds) {
-  if (!has_frame())
-    return bounds;
-
   gfx::Rect window_bounds(bounds);
 #if defined(OS_WIN)
   HWND hwnd = GetAcceleratedWidget();
@@ -1167,7 +1164,7 @@ gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
       window_->non_client_view()->GetWindowBoundsForClientBounds(dpi_bounds));
 #endif
 
-  if (menu_bar_ && menu_bar_visible_) {
+  if (has_frame() && menu_bar_ && menu_bar_visible_) {
     window_bounds.set_y(window_bounds.y() - kMenuBarHeight);
     window_bounds.set_height(window_bounds.height() + kMenuBarHeight);
   }
@@ -1176,9 +1173,6 @@ gfx::Rect NativeWindowViews::ContentBoundsToWindowBounds(
 
 gfx::Rect NativeWindowViews::WindowBoundsToContentBounds(
     const gfx::Rect& bounds) {
-  if (!has_frame())
-    return bounds;
-
   gfx::Rect content_bounds(bounds);
 #if defined(OS_WIN)
   HWND hwnd = GetAcceleratedWidget();
@@ -1195,7 +1189,7 @@ gfx::Rect NativeWindowViews::WindowBoundsToContentBounds(
       display::win::ScreenWin::ScreenToDIPSize(hwnd, content_bounds.size()));
 #endif
 
-  if (menu_bar_ && menu_bar_visible_) {
+  if (has_frame() && menu_bar_ && menu_bar_visible_) {
     content_bounds.set_y(content_bounds.y() + kMenuBarHeight);
     content_bounds.set_height(content_bounds.height() - kMenuBarHeight);
   }


### PR DESCRIPTION
Properly handle the bounds on frameless window type (win32 only)

Auditors: @bridiver @bbondy @jonathansampson 