### PR TITLE
add isRendererInitiated property on did-navigate event

### DIFF
--- a/atom/browser/api/atom_api_web_contents.cc
+++ b/atom/browser/api/atom_api_web_contents.cc
@@ -874,11 +874,12 @@ void WebContents::DidFinishNavigation(
   auto url = navigation_handle->GetURL();
   if (navigation_handle->HasCommitted() && !navigation_handle->IsErrorPage()) {
     bool is_in_page = navigation_handle->IsSamePage();
+    bool is_renderer_initiated = navigation_handle->IsRendererInitiated();
     if (!is_in_page) {
       Emit("load-commit", url, is_main_frame);
     }
     if (is_main_frame && !is_in_page) {
-      Emit("did-navigate", url);
+      Emit("did-navigate", url, is_renderer_initiated);
     } else if (is_in_page) {
       Emit("did-navigate-in-page", url, is_main_frame);
     }

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -28,7 +28,7 @@ var WEB_VIEW_EVENTS = {
   'devtools-focused': [],
   'new-window': ['url', 'frameName', 'disposition', 'options'],
   'will-navigate': ['url'],
-  'did-navigate': ['url'],
+  'did-navigate': ['url', 'isRendererInitiated'],
   'did-navigate-in-page': ['url', 'isMainFrame'],
   'close': [],
   'crashed': [],


### PR DESCRIPTION
This is needed to mitigate https://github.com/brave/browser-laptop/issues/4973,
we should only set the frame title on navigation if it was not renderer-initiated
(ex: by clicking the back/forward buttons)

Auditors: @bbondy